### PR TITLE
removed copy_idls

### DIFF
--- a/rosidl_typesupport_opendds_cpp/bin/rosidl_typesupport_opendds_cpp
+++ b/rosidl_typesupport_opendds_cpp/bin/rosidl_typesupport_opendds_cpp
@@ -8,8 +8,6 @@ from rosidl_typesupport_opendds_cpp import generate_cpp
 from rosidl_typesupport_opendds_cpp import generate_idl
 from rosidl_typesupport_opendds_cpp import generate_dds_opendds_cpp
 
-import glob, os, shutil
-
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description='Generate the C++ interfaces for OpenDDS.',

--- a/rosidl_typesupport_opendds_cpp/bin/rosidl_typesupport_opendds_cpp
+++ b/rosidl_typesupport_opendds_cpp/bin/rosidl_typesupport_opendds_cpp
@@ -49,18 +49,6 @@ def main(argv=sys.argv[1:]):
     if rc:
         return rc
 
-    copy_idls('../../rmw_build/no_anon_type_idls/action_msgs/msg','rosidl_generator_dds_idl/action_msgs/msg/dds_opendds/')
-    copy_idls('../../rmw_build/no_anon_type_idls/action_msgs/srv','rosidl_generator_dds_idl/action_msgs/srv/dds_opendds/')
-    copy_idls('../../rmw_build/no_anon_type_idls/example_interfaces/action','rosidl_generator_dds_idl/example_interfaces/action/dds_opendds/')
-    copy_idls('../../rmw_build/no_anon_type_idls/example_interfaces/msg','rosidl_generator_dds_idl/example_interfaces/msg/dds_opendds/')
-    copy_idls('../../rmw_build/no_anon_type_idls/rcl_interfaces/msg','rosidl_generator_dds_idl/rcl_interfaces/msg/dds_opendds')
-    copy_idls('../../rmw_build/no_anon_type_idls/rcl_interfaces/srv','rosidl_generator_dds_idl/rcl_interfaces/srv/dds_opendds/')
-    copy_idls('../../rmw_build/no_anon_type_idls/std_msgs','rosidl_generator_dds_idl/std_msgs/msg/dds_opendds/')
-    copy_idls('../../rmw_build/no_anon_type_idls/test_msgs/action','rosidl_generator_dds_idl/test_msgs/action/dds_opendds/')
-    copy_idls('../../rmw_build/no_anon_type_idls/test_msgs/msg','rosidl_generator_dds_idl/test_msgs/msg/dds_opendds/')
-    copy_idls('../../rmw_build/no_anon_type_idls/test_msgs/srv','rosidl_generator_dds_idl/test_msgs/srv/dds_opendds/')
-    copy_idls('../../rmw_build/no_anon_type_idls/unique_identifier_msgs','rosidl_generator_dds_idl/unique_identifier_msgs/msg/dds_opendds/')
-
     return generate_dds_opendds_cpp(
         generator_args['package_name'],
         generator_args.get('additional_files', []),

--- a/rosidl_typesupport_opendds_cpp/bin/rosidl_typesupport_opendds_cpp
+++ b/rosidl_typesupport_opendds_cpp/bin/rosidl_typesupport_opendds_cpp
@@ -10,17 +10,6 @@ from rosidl_typesupport_opendds_cpp import generate_dds_opendds_cpp
 
 import glob, os, shutil
 
-def copy_idls(source_rel_path, dest_rel_path, cwd=os.getcwd()):
-    updated_idls_path=os.path.abspath(os.path.join(cwd, source_rel_path))
-    original_idls_path=os.path.abspath(os.path.join(cwd,dest_rel_path))
-    if os.path.isdir(updated_idls_path) and os.path.isdir(original_idls_path):
-        files = glob.iglob(os.path.join(updated_idls_path, "*_.idl"))
-        print('copying from ', updated_idls_path, ' to ', original_idls_path)
-        for file in files:
-            if os.path.isfile(file):
-                print('coping file ', file)
-                shutil.copy2(file, original_idls_path)
-
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
         description='Generate the C++ interfaces for OpenDDS.',


### PR DESCRIPTION
# Description
This change removes the temporary scripts that copy idl files for anonymous type support.
This change depends on the IDL4 Anonymous Types PR1754 in the OpenDDS repo being merged first.

Fixes (Trello link here OR reason to fix if not on Trello)
https://trello.com/c/IW1I6H7Q/62-remove-the-current-workaround-that-supports-anonymous-types

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- Pub/sub and service/client tests.

# Checklist:
- [ ] I have performed a self-review of my own code
- [ ] New and existing system tests pass locally with my changes (when applicable)
- [ ] Any dependent changes have been merged and published in downstream modules